### PR TITLE
Specify GCC/QEMU path and check python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ include mk/cmsis.mk
 prebuild: $(CMSIS)/$(PLAT)
 
 check:
-	$(PYTHON) -m tests -p $(PLAT)
+	$(PYTHON) -m tests -p $(PLAT) --qemu $(QEMU_SYSTEM_ARM) --cc $(CC)
 
 clean:
 	find . -name "*.o" -type f -delete

--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -1,4 +1,4 @@
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 CC = $(CROSS_COMPILE)gcc
 AS = $(CROSS_COMPILE)as
 AR = $(CROSS_COMPILE)ar
@@ -8,6 +8,7 @@ HOSTCC  = gcc
 WGET = wget
 # FIXME: check version >= 3.5
 PYTHON = python3
+QEMU_SYSTEM_ARM ?= qemu-system-arm
 
 # FIXME: configurable via menuconfig or command line
 CFLAGS_OPT = -Os # -flto

--- a/platform/stm32p103/build.mk
+++ b/platform/stm32p103/build.mk
@@ -3,7 +3,7 @@ ifeq ($(shell lsb_release -c -s),trusty)
 endif
 
 run: $(NAME).bin
-	$(Q)qemu-system-arm \
+	$(Q)$(QEMU_SYSTEM_ARM) \
 	    -semihosting \
 	    $(REDIRECT_SERIAL) \
 	    -nographic \
@@ -12,7 +12,7 @@ run: $(NAME).bin
 	    -kernel $<
 
 dbg: $(NAME).bin
-	$(Q)qemu-system-arm \
+	$(Q)$(QEMU_SYSTEM_ARM) \
 	    -semihosting \
 	    $(REDIRECT_SERIAL) \
 	    -nographic \

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,3 +1,8 @@
+import sys
+if sys.version_info < (3, 5):
+    print ("Only support python version >= 3.5")
+    exit(1)
+
 import argparse
 import tests.runner as runner
 from tests.runner import PikoTest

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -16,6 +16,8 @@ if __name__ == '__main__':
                         help='no output unless one or more tests fail')
     parser.add_argument('--debug', action='store_true', help='Run test and wait for gdb connect')
     parser.add_argument('-p', '--platform', default='stm32p103')
+    parser.add_argument('--qemu', default='qemu-system-arm')
+    parser.add_argument('--cc', default='arm-none-eabi-gcc')
     parser.add_argument('--timeout', type=int, default=60)
     parser.add_argument('--slowest', action='store_true', dest='print_slow',
                         help='print the slowest 10 tests')

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -132,8 +132,8 @@ class PikoTest:
               % (locale.getpreferredencoding(False),
                  sys.getfilesystemencoding()))
         print()
-        print_qemu_version()
-        print_gcc_version()
+        print_qemu_version(self.ns)
+        print_gcc_version(self.ns)
 
     def accumulate_result(self, test, result):
         ok, test_time = result
@@ -212,8 +212,8 @@ class PikoTest:
         sys.exit(0)
 
 
-def print_qemu_version():
-    cmd = ["qemu-system-arm", "--version"]
+def print_qemu_version(ns):
+    cmd = [ns.qemu, "--version"]
     res = subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE,
                          stderr=subprocess.DEVNULL)
     print()
@@ -221,8 +221,8 @@ def print_qemu_version():
     print()
 
 
-def print_gcc_version():
-    cmd = ["arm-none-eabi-gcc", "--version"]
+def print_gcc_version(ns):
+    cmd = [ns.cc, "--version"]
     res = subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE,
                          stderr=subprocess.DEVNULL)
     print()


### PR DESCRIPTION
1. Check python version should >= 3.5 to import `runner`
2. Avoid hardcode of GCC/QEMU path