### PR TITLE
Bitmap: Fix problem about idle thread not performing context switch.

### DIFF
--- a/kernel/sched/bitmap.c
+++ b/kernel/sched/bitmap.c
@@ -99,12 +99,12 @@ static int sched_bitmap_elect(int flags)
     if (flags == SCHED_OPT_RESTORE_ONLY)
         thread_restore(next);  // switch_to_restore_only
     else {
-        if (next == thread_idle || next == current)
-            return 0;
-        if (flags == SCHED_OPT_TICK) {
+        if (flags == SCHED_OPT_TICK && current != thread_idle) {
             thread_enqueue(current, sched_struct.expire);
             current->ti_state = THREAD_STATE_EXPIRED;
         }
+        if (next == current)
+            return 0;
         switch_to(next, current);
     }
 


### PR DESCRIPTION
4 conditions.

1. **next != idle && curr != idle**: next thread was removed from the runqueue, if the current thread is preemptived by PendSV, the task is not complete. Need to add it back to the expire runqueue. So I place (next == current) condition below the SCHED_OPT_TICK condition.

2. **next == idle && curr != idle**: the original code will return directly, not performing context switch with current thread, just remove the condition.

3. **next != idle && curr == idle**: continue from 2. Because expire runqueue has one item, the next thread wil not be idle anymore. Consider idle thread is not in the runqueue at the beginning, we can't add it back to runqueue again. I add a constraint (current != thread_idle) in the SCHED_OPT_TICK condition.

4. **next == idle && current == idle**: This is wrong situation, it occurs at situation 2 with flags != SCHED_OPT_TICK. I do not add any error detection in this pull request, i.e. `if (next == idle && curr == idle) return -1;`

However, I can not pass the Travis test and has 6 over 53 test case failed. But I have the same 6 test case failed without this modification. I guess it is something wrong in my environment setting.